### PR TITLE
Ignore properties on array's prototype when iterating.

### DIFF
--- a/grunt/js/analytics.js
+++ b/grunt/js/analytics.js
@@ -64,7 +64,9 @@ _analytics.setup = (function(polyfill, config, omniture, trackClick, trackPage, 
             setVariable('fullPageDescription', pageName.substring(0,255));
         }
         for (name in config) {
-            setVariable(name, config[name]);
+            if (config.hasOwnProperty(name)) {
+                setVariable(name, config[name]);
+            }
         }
     }
 
@@ -91,10 +93,8 @@ _analytics.setup = (function(polyfill, config, omniture, trackClick, trackPage, 
 
     function checkMandatoryConfig(){
         for (var name in mandatory){
-            if (mandatory.hasOwnProperty(name)) {
-                if (!config[mandatory[name]]){
-                    console.error('Mandatory config is missing: ', mandatory[name]);
-                }
+            if (mandatory.hasOwnProperty(name) && !config[mandatory[name]]) {
+                console.error('Mandatory config is missing: ', mandatory[name]);
             }
         }
     }
@@ -119,10 +119,12 @@ _analytics.setup = (function(polyfill, config, omniture, trackClick, trackPage, 
         var arrValues = [], i, type,
             varName = item.name,
             types = ['prop','eVar','list','hier'];
-        for (i in types){
-            type = types[i];
-            if (item[type]){
-                arrValues.push(type + item[type]);
+        for (i in types) {
+            if (types.hasOwnProperty(i)) {
+                type = types[i];
+                if (item[type]){
+                    arrValues.push(type + item[type]);
+                }
             }
         }
         config.variablesMap[varName] = arrValues;

--- a/grunt/js/core/track-page.js
+++ b/grunt/js/core/track-page.js
@@ -7,10 +7,15 @@ _analytics.trackPage = (function(config,omniture){
         omniture.setEvent('pageLoad');
 
         for (name in config.loadVariables){
-            omniture.setVariable(name, config.loadVariables[name], 'load');
+            if (config.loadVariables.hasOwnProperty(name)) {
+                omniture.setVariable(name, config.loadVariables[name], 'load');
+            }
         }
+
         for (name in config.loadEvents){
-            omniture.setEvent(config.loadEvents[name], 'load');
+            if (config.loadEvents.hasOwnProperty(name)) {
+                omniture.setEvent(config.loadEvents[name], 'load');
+            }
         }
 
         omniture.trackPage();

--- a/grunt/js/utils/logger.js
+++ b/grunt/js/utils/logger.js
@@ -37,20 +37,25 @@ _analytics.logger = (function(config){
         var eventsMap = config.eventsMap,
             name;
         for (name in eventsMap){
-            if (eventsMap[name]==eventID) return name;
+            if (eventsMap.hasOwnProperty(name) && eventsMap[name] == eventID) {
+                return name;
+            }
         }
         return '';
     }
+
     function logS(linkDetails, events, mappedVars){
         if (!(debugging && console && console.group)){ return; }
+
         var arrDetails, x;
         log('start','tracking event');
-
             if (linkDetails){
                 console.groupCollapsed('linkDetails');
                 arrDetails = linkDetails.split('|');
                 for (x in arrDetails){
-                    log(config.linkDetailsMap[x], arrDetails[x]);
+                    if (arrDetails.hasOwnProperty(x)) {
+                        log(config.linkDetailsMap[x], arrDetails[x]);
+                    }
                 }
                 console.groupEnd();
             }
@@ -58,14 +63,18 @@ _analytics.logger = (function(config){
                 arrDetails = events.split(',');
                 console.groupCollapsed('events');
                 for (x in arrDetails){
-                    log(getEventName(arrDetails[x]), arrDetails[x]);
+                    if (arrDetails.hasOwnProperty(x)) {
+                        log(getEventName(arrDetails[x]), arrDetails[x]);
+                    }
                 }
                 console.groupEnd();
             }
             console.groupCollapsed('All Changed Variables');
                 for (x in mappedVars){
-                    if (mappedVars[x].val!==String(config[x])){
-                        log(x, mappedVars[x].val);
+                    if (mappedVars.hasOwnProperty(x)) {
+                        if (mappedVars[x].val!==String(config[x])){
+                            log(x, mappedVars[x].val);
+                        }
                     }
                 }
             console.groupEnd();


### PR DESCRIPTION
This fixes a bug where when methods are applied to Array.prototype (e.g. in
Ember.js), analytics would complain about a lot of missing mandatory configs!
