### PR TITLE
Fix navigation in documentation (The Page Type Link)

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -7,7 +7,7 @@ Tracking :
   Clicks :
   Variables :
   Events:
-Page Type:
+Page Types:
   Searches:
   Errors:
 Manual Trigger:

--- a/_site/changes.html
+++ b/_site/changes.html
@@ -107,9 +107,9 @@
                 
                 
                 
-                <li id='page-type-tab' aria-controls="page-type-tab-contents" role="tab" class="tab
+                <li id='page-types-tab' aria-controls="page-types-tab-contents" role="tab" class="tab
                     
-                    "><a href="index.html#page-type" class="intro ellipsis internal-link">Page Type</a>
+                    "><a href="index.html#page-types" class="intro ellipsis internal-link">Page Types</a>
                 </li>
                 
                 
@@ -210,9 +210,9 @@
             
             
             
-            <div id="page-type-tab-contents" class="tabpanel
+            <div id="page-types-tab-contents" class="tabpanel
                 
-                " aria-labeledby="page-type-tab" role="tabpanel" >
+                " aria-labeledby="page-types-tab" role="tabpanel" >
                 <section class="tabcontents tabs-container page-nav">
                     <ul class="nav tabs clearfix">
                         
@@ -220,7 +220,7 @@
                         
                         <li class="tab ">
                             
-                            <a href="index.html#searches" class="ellipsis internal-link" data-diff="page-type/searches" data-diff-demos="
+                            <a href="index.html#searches" class="ellipsis internal-link" data-diff="page-types/searches" data-diff-demos="
                                 ">Searches</a>
                         </li>
                         
@@ -228,7 +228,7 @@
                         
                         <li class="tab ">
                             
-                            <a href="index.html#errors" class="ellipsis internal-link" data-diff="page-type/errors" data-diff-demos="
+                            <a href="index.html#errors" class="ellipsis internal-link" data-diff="page-types/errors" data-diff-demos="
                                 ">Errors</a>
                         </li>
                         
@@ -304,7 +304,7 @@
         <ul class="alpha skycom-12">
             <li class="right meta-data skycom-2" >
                 <div class="intro">Analytics v<span id="current-version">1.4.4rc2</span></div>
-                <small class="right">Updated: 14-04-2014</small>
+                <small class="right">Updated: 23-04-2014</small>
             </li>
         </ul>
     </div>

--- a/_site/index.html
+++ b/_site/index.html
@@ -107,9 +107,9 @@
                 
                 
                 
-                <li id='page-type-tab' aria-controls="page-type-tab-contents" role="tab" class="tab
+                <li id='page-types-tab' aria-controls="page-types-tab-contents" role="tab" class="tab
                     
-                    "><a href="index.html#page-type" class="intro ellipsis internal-link">Page Type</a>
+                    "><a href="index.html#page-types" class="intro ellipsis internal-link">Page Types</a>
                 </li>
                 
                 
@@ -210,9 +210,9 @@
             
             
             
-            <div id="page-type-tab-contents" class="tabpanel
+            <div id="page-types-tab-contents" class="tabpanel
                 
-                " aria-labeledby="page-type-tab" role="tabpanel" >
+                " aria-labeledby="page-types-tab" role="tabpanel" >
                 <section class="tabcontents tabs-container page-nav">
                     <ul class="nav tabs clearfix">
                         
@@ -220,7 +220,7 @@
                         
                         <li class="tab ">
                             
-                            <a href="index.html#searches" class="ellipsis internal-link" data-diff="page-type/searches" data-diff-demos="
+                            <a href="index.html#searches" class="ellipsis internal-link" data-diff="page-types/searches" data-diff-demos="
                                 ">Searches</a>
                         </li>
                         
@@ -228,7 +228,7 @@
                         
                         <li class="tab ">
                             
-                            <a href="index.html#errors" class="ellipsis internal-link" data-diff="page-type/errors" data-diff-demos="
+                            <a href="index.html#errors" class="ellipsis internal-link" data-diff="page-types/errors" data-diff-demos="
                                 ">Errors</a>
                         </li>
                         
@@ -1792,7 +1792,7 @@ analytics.trackPage(SITECAT_CONFIG);
         <ul class="alpha skycom-12">
             <li class="right meta-data skycom-2" >
                 <div class="intro">Analytics v<span id="current-version">1.4.4rc2</span></div>
-                <small class="right">Updated: 14-04-2014</small>
+                <small class="right">Updated: 23-04-2014</small>
             </li>
         </ul>
     </div>

--- a/_site/test.html
+++ b/_site/test.html
@@ -131,7 +131,7 @@
         <ul class="alpha skycom-12">
             <li class="right meta-data skycom-2" >
                 <div class="intro">Analytics v<span id="current-version">1.4.4rc2</span></div>
-                <small class="right">Updated: 14-04-2014</small>
+                <small class="right">Updated: 23-04-2014</small>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
The Page Types link in the navigation on the documentation is broken. This commit should fix it.
